### PR TITLE
Accelerating ACE wrapper

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InteratomicBasisPotentials"
 uuid = "37c59853-c2ad-4e3a-930c-a41b2395fb19"
 authors = ["Dallas Foster <fostdall@mit.edu>"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 ACE1 = "e3f9bc04-086e-409a-ba78-e9769fe067bb"

--- a/src/BasisSystems/ACE/ace.jl
+++ b/src/BasisSystems/ACE/ace.jl
@@ -1,6 +1,7 @@
 using JuLIP: Atoms, JVec, JMat, site_energy, Ref
 using JuLIP.Chemistry: AtomicNumber
 import ACE1
+using Unitful, UnitfulAtomic
 
 struct ACE <: BasisSystem
     species           :: Vector{Symbol}
@@ -10,30 +11,30 @@ struct ACE <: BasisSystem
     csp               :: Real
     r0                :: Real 
     rcutoff           :: Real
+    rpib              :: InteratomicBasisPotentials.ACE1.RPIBasis
 end 
 
-function ACE(species :: Vector{Symbol}; body_order = 4, polynomial_degree = 6, 
-            wL = 1.0, csp = 1.0, r0 = 0.95, rcutoff = 5.0)
-    ACE(species, body_order, polynomial_degree, wL, csp, r0, rcutoff)
+function ACE(; species = [:X], body_order = 4, polynomial_degree = 6, 
+               wL = 1.5, csp = 1.0, r0 = 2.5, rcutoff = 5.0)
+    rpib = InteratomicBasisPotentials.ACE1.rpi_basis(;
+                species = species,
+                N       = body_order - 1,
+                maxdeg  = polynomial_degree,
+                D       = InteratomicBasisPotentials.ACE1.SparsePSHDegree(; wL = wL, csp = csp),
+                r0      = r0, 
+                rin     = 0.65*r0,
+                rcut    = rcutoff,
+                pin     = 0,
+           )
+    return ACE(species, body_order, polynomial_degree, wL, csp, r0, rcutoff, rpib)
 end
 
-length(ace::ACE) = length(get_rpi(ace))
-
-function get_rpi(ace::ACE)
-    ACE1.rpi_basis(;
-    species = ace.species,
-    N       = ace.body_order - 1,
-    maxdeg  = ace.polynomial_degree,
-    D       = ACE1.SparsePSHDegree(; wL = ace.wL, csp = ace.csp),
-    r0      = ace.r0, 
-    rin     = 0.65*ace.r0,
-    rcut    = ace.rcutoff,
-    pin     = 0,
-    )
+function get_rpi(ace)
+    return ace.rpib
 end
 
-get_rcutoff(ace::ACE) = ace.basis_params.rcutoff
-get_species(ace::ACE) = ace.basis_params.species
+
+Base.length(ace::ACE) = length(ace.rpib)
 
 function convert_system_to_atoms(system::AbstractSystem)
     positions = [ustrip.(position) for position in AtomsBase.position(system)]
@@ -46,11 +47,11 @@ function convert_system_to_atoms(system::AbstractSystem)
 end
 
 function compute_local_descriptors(A::AbstractSystem, ace::ACE)
-    [site_energy(get_rpi(ace), convert_system_to_atoms(A), i) for i = 1:length(A)]
+    [site_energy(ace.rpib, convert_system_to_atoms(A), i) for i = 1:length(A)]
 end
 
 function compute_force_descriptors(A::AbstractSystem, ace::ACE)
-    ftemp = ACE1.forces(get_rpi(ace), convert_system_to_atoms(A))
+    ftemp = ACE1.forces(ace.rpib, convert_system_to_atoms(A))
     f = [zeros(3, length(ace)) for i = 1:length(A)]
 
     for i = 1:length(A)
@@ -64,7 +65,7 @@ function compute_force_descriptors(A::AbstractSystem, ace::ACE)
 end
 
 function compute_virial_descriptors(A::AbstractSystem, ace::ACE)
-    Wtemp = ACE1.virial(get_rpi(ace), convert_system_to_atoms(A))
+    Wtemp = ACE1.virial(ace.rpib, convert_system_to_atoms(A))
     W = zeros(6, length(ace))
 
     for k = 1:length(ace)

--- a/src/BasisSystems/ACE/ace.jl
+++ b/src/BasisSystems/ACE/ace.jl
@@ -11,16 +11,16 @@ struct ACE <: BasisSystem
     csp               :: Real
     r0                :: Real 
     rcutoff           :: Real
-    rpib              :: InteratomicBasisPotentials.ACE1.RPIBasis
+    rpib              :: ACE1.RPIBasis
 end 
 
 function ACE(; species = [:X], body_order = 4, polynomial_degree = 6, 
                wL = 1.5, csp = 1.0, r0 = 2.5, rcutoff = 5.0)
-    rpib = InteratomicBasisPotentials.ACE1.rpi_basis(;
+    rpib = ACE1.rpi_basis(;
                 species = species,
                 N       = body_order - 1,
                 maxdeg  = polynomial_degree,
-                D       = InteratomicBasisPotentials.ACE1.SparsePSHDegree(; wL = wL, csp = csp),
+                D       = ACE1.SparsePSHDegree(; wL = wL, csp = csp),
                 r0      = r0, 
                 rin     = 0.65*r0,
                 rcut    = rcutoff,
@@ -33,6 +33,13 @@ function get_rpi(ace)
     return ace.rpib
 end
 
+function get_rcutoff(ace::ACE)
+    return ace.rcutoff
+end
+
+function get_species(ace::ACE)
+    return ace.species
+end
 
 Base.length(ace::ACE) = length(ace.rpib)
 
@@ -43,17 +50,16 @@ function convert_system_to_atoms(system::AbstractSystem)
     atomic_number = AtomicNumber.(AtomsBase.atomic_number(system))
     cell = JMat(ustrip.(vcat(AtomsBase.bounding_box(system)...)))
     pbc = JVec([pbc == Periodic() ? true : false for pbc in AtomsBase.boundary_conditions(system)]...)
-    Atoms(X = positions, P = velocities, M = masses, Z = atomic_number, cell = cell, pbc = pbc)
+    return Atoms(X = positions, P = velocities, M = masses, Z = atomic_number, cell = cell, pbc = pbc)
 end
 
 function compute_local_descriptors(A::AbstractSystem, ace::ACE)
-    [site_energy(ace.rpib, convert_system_to_atoms(A), i) for i = 1:length(A)]
+    return [site_energy(ace.rpib, convert_system_to_atoms(A), i) for i = 1:length(A)]
 end
 
 function compute_force_descriptors(A::AbstractSystem, ace::ACE)
     ftemp = ACE1.forces(ace.rpib, convert_system_to_atoms(A))
     f = [zeros(3, length(ace)) for i = 1:length(A)]
-
     for i = 1:length(A)
         for j = 1:3 
             for k = 1:length(ace)
@@ -61,13 +67,12 @@ function compute_force_descriptors(A::AbstractSystem, ace::ACE)
             end
         end
     end
-    f
+    return f
 end
 
 function compute_virial_descriptors(A::AbstractSystem, ace::ACE)
     Wtemp = ACE1.virial(ace.rpib, convert_system_to_atoms(A))
     W = zeros(6, length(ace))
-
     for k = 1:length(ace)
         count = 1
         for (i, j) in zip( [1, 2, 3, 3, 3, 2], [1, 2, 3, 2, 1, 1])
@@ -75,9 +80,9 @@ function compute_virial_descriptors(A::AbstractSystem, ace::ACE)
             count +=1
         end
     end
-    W
+    return W
 end
 
 function compute_all_descriptors(A::AbstractSystem, ace::ACE)
-    compute_local_descriptors(A, ace), compute_force_descriptors(A, ace), compute_virial_descriptors(A, ace)
+    return compute_local_descriptors(A, ace), compute_force_descriptors(A, ace), compute_virial_descriptors(A, ace)
 end

--- a/test/ACE/ace_test.jl
+++ b/test/ACE/ace_test.jl
@@ -20,7 +20,8 @@ box = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 bcs = [Periodic(), Periodic(), Periodic()]
 system = FlexibleSystem(atoms, box * u"Å", bcs)
 
-ace = ACE([:Ar], 2, 8, 1.0, 1.0, 0.4, 2.0)
+ace = ACE( species = [:Ar], body_order = 2, polynomial_degree = 8, 
+           wL = 1.0, csp = 1.0, r0 = 0.4, rcutoff = 2.0)
 @test isa(ace, BasisSystem)
 e = sum(compute_local_descriptors(system, ace))
 @test isa(e, AbstractVector)

--- a/test/log.lammps
+++ b/test/log.lammps
@@ -1,2 +1,4 @@
 LAMMPS (23 Jun 2022 - Update 1)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
 log none


### PR DESCRIPTION
Modification of the wrapper to ACE1.jl (`src/BasisSystems/ACE/ace.jl`) to accelerate descriptor calculations. The computation of `ACE1.rpi_basis` is expensive, now its computation is performed only once, when the ACE constructor is called.
